### PR TITLE
Added require form to build.boot file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ boot watch fingerprint
 ### build.boot file
 
 ```clojure
+(require '[pointslope.boot-fingerprint :refer [fingerprint]])
+
 (deftask run
   []
   (comp (watch) (fingerprint)))


### PR DESCRIPTION
As it's not quite obvious that the namespace is `pointslope.boot-fingerprint`
